### PR TITLE
Adds working ci.sh

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -1,0 +1,18 @@
+# static syntax check
+python3 -m py_compile src/main/*.py
+if [ $? -eq 1 ]
+then
+	exit 2
+fi
+
+# run tests
+cd src
+python3 -m unittest discover test/
+if [ $? -eq 1 ]
+then
+	exit 1
+fi
+
+# everything is fine
+exit 0
+

--- a/src/test/test_repo_tester.py
+++ b/src/test/test_repo_tester.py
@@ -14,7 +14,7 @@ class test_repo_tester(unittest.TestCase):
         with open('test/json_pull_request_example.txt', 'r') as payloadfile:         
             payload = payloadfile.read()                                        
             self.assertTrue(repo_test(payload) == 10)                           
-                                                                                
+
 if __name__ == '__main__':                                                      
     unittest.main()                                                             
                                                                                 


### PR DESCRIPTION
There are no tests for ci.sh, because that just wouldn't make sense. But I did test it manually. It returns 0 if everything works, 1 if one or more tests fail, and 2 if the static syntax check fails.