### PR TITLE
Fixes ci.sh

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -1,13 +1,13 @@
 # static syntax check
-python3 -m py_compile DD2480_group_19_CI/src/main/*.py
+cd DD2480_group_19_CI
+python3 -m py_compile src/main/*.py
 if [ $? -eq 1 ]
 then
 	exit 2
 fi
 
 # run tests
-cd DD2480_group_19_CI/src
-python3 -m unittest discover test/
+python3 -m unittest discover src/test/
 if [ $? -eq 1 ]
 then
 	exit 1

--- a/src/test/test_repo_tester.py
+++ b/src/test/test_repo_tester.py
@@ -21,7 +21,8 @@ class test_repo_tester(unittest.TestCase):
     something other than 0, 1, 2. If ci.sh is malformed or missing,
     repo_test should return -1.
     """                                                                               
-    def test_invalid1(self):                                                           
+    def test_invalid1(self):
+        subprocess.run(["pwd"])
         with open('src/test/json_push_invalid1.txt', 'r') as payloadfile:         
             payload = payloadfile.read()                                        
             self.assertTrue(repo_test(json.loads(payload)) == -1)

--- a/src/test/test_repo_tester.py
+++ b/src/test/test_repo_tester.py
@@ -22,7 +22,6 @@ class test_repo_tester(unittest.TestCase):
     repo_test should return -1.
     """                                                                               
     def test_invalid1(self):
-        subprocess.run(["pwd"])
         with open('src/test/json_push_invalid1.txt', 'r') as payloadfile:         
             payload = payloadfile.read()                                        
             self.assertTrue(repo_test(json.loads(payload)) == -1)


### PR DESCRIPTION
ci.sh should now be runnable and work correctly from the parent directory of the directory containing ci.sh.

Fixes #57 