### PR TITLE
Fixes #73. Adds the route /all to list all past builds

### DIFF
--- a/src/main/app.py
+++ b/src/main/app.py
@@ -60,6 +60,15 @@ def build_list():
     build_list = history.fetch_n_last(10)
     return render_template('build_list.html', build_list=build_list)
 
+@app.route("/all")
+def build_all_list():
+    """
+    Lists all past builds with a link to the detailed page of the build.
+    """
+    build_list = history.fetch_all()
+    return render_template('build_list.html', build_list=build_list)
+
+
 def main():
     """
     Configures the API token and the build database.

--- a/src/main/history.py
+++ b/src/main/history.py
@@ -57,6 +57,13 @@ class History:
         if(nr_documents < n):
             return self.db['builds'].find()
         return self.db['builds'].find().skip(nr_documents - n)
+    
+    def fetch_all(self):
+        """
+        Fetch all of the documents to add to the history
+        """
+
+        return self.db['builds'].find()
 
     @staticmethod
     def serialize(build_id, date_rec, date_end, status):


### PR DESCRIPTION
Closes #73. Added a route '/all' to `app.py` to list all builds. Also added the function `fetch_all` to `history.py`